### PR TITLE
Add support for Makefile & Project based build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+
+TARGET = $(shell gcc -dumpmachine)
+
+ifeq ($(TARGET), $(shell gcc -dumpmachine))
+prefix = $(dir $(shell which gnatls))..
+else
+prefix = $(dir $(shell which $(TARGET)-gnatls))..
+endif
+
+BUILD_KIND=Debug
+LIBRARY_TYPE=relocatable
+
+PRJ_OPTS=-XLIBRARY_TYPE=$(LIBRARY_TYPE) -XPRJ_BUILD=$(BUILD_KIND)
+
+all: build
+
+build:
+	gprbuild $(PRJ_OPTS) pragmarc.gpr
+
+install:
+	gprinstall -p --prefix=$(prefix) $(PRJ_OPTS) \
+		--build-name=$(LIBRARY_TYPE) \
+		pragmarc.gpr
+
+clean:
+	gprclean $(PRJ_OPTS) pragmarc.gpr

--- a/pragmarc.gpr
+++ b/pragmarc.gpr
@@ -1,0 +1,53 @@
+library project PragMarc is
+
+   --------------------------
+   -- Static / Relocatable --
+   --------------------------
+
+   type Library_Kind is ("relocatable", "static", "static-pic");
+   Library_Type : Library_Kind := external ("LIBRARY_TYPE", "static");
+
+   ----------------
+   -- Build Type --
+   ----------------
+
+   type Build_Type is ("Debug", "Release");
+   Build : Build_Type := external ("PRJ_BUILD", "Debug");
+
+   for Source_Dirs use (".");
+   for Object_Dir use "obj";
+   for Library_Dir use "lib";
+   for Library_Name use "pragmarc";
+   for Library_Kind use Library_Type;
+
+   case Build is
+      when "Debug" =>
+         for Object_Dir use Project'Object_Dir & "/debug/" & Library_Type;
+         for Library_Dir use Project'Library_Dir & "/debug/" & Library_Type;
+      when "Release" =>
+         for Object_Dir use Project'Object_Dir & "/release/" & Library_Type;
+         for Library_Dir use Project'Library_Dir & "/release/" & Library_Type;
+   end case;
+
+   Common_Options := ("-gnat2012", "-gnatwcfijkmruv");
+   --  Common options used for the Debug and Release modes
+
+   Debug_Options :=
+     ("-g", "-gnata", "-gnatVa", "-gnatQ", "-gnato", "-Wall");
+
+   Release_Options := ("-O2", "-gnatn");
+
+   package Compiler is
+
+      for Driver ("Makefile") use "";
+
+      case Build is
+         when "Debug" =>
+            for Default_Switches ("Ada") use Common_Options & Debug_Options;
+         when "Release" =>
+            for Default_Switches ("Ada") use Common_Options & Release_Options;
+      end case;
+
+   end Compiler;
+
+end PragMarc;


### PR DESCRIPTION
The default build is Debug & relocatable. Variable LIBRARY_TYPE can be used to select a static or static-pic build, and BUILD_KIND can be set to Release.